### PR TITLE
Add appveyor, drop 6 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
 os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+environment:
+  matrix:
+    # node.js
+    - nodejs_version: "10"
+    - nodejs_version: "8"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - yarn
+
+test_script:
+  - node --version
+  - yarn --version
+  - yarn run coverage
+
+build: off
+
+# build version format
+version: "{build}"

--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
     "url": "git://github.com/cb1kenobi/cli-kit.git"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   }
 }


### PR DESCRIPTION
async/await is now used so I assume we need a 7.6 minimum?