### PR TITLE
Fix output steam and exit code on error

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -88,8 +88,10 @@ export default class CLI extends Context {
 					await contexts[1].renderHelp({ err });
 
 					// istanbul ignore if
-					if (params.helpExitCode !== undefined) {
-						process.exit(params.helpExitCode);
+					if (err) {
+						process.exitCode = 1;
+					} else if (params.helpExitCode !== undefined) {
+						process.exitCode = params.helpExitCode;
 					}
 				}
 			});

--- a/src/cli.js
+++ b/src/cli.js
@@ -195,6 +195,9 @@ export default class CLI extends Context {
 			$args = await this.parse(unparsedArgs ? unparsedArgs.slice() : process.argv.slice(2));
 			let cmd = $args.contexts[0];
 
+			if (!(cmd instanceof Command) && $args.enteredUnknownCommand) {
+				throw new Error(`Unknown command ${$args.unknownCommand}`);
+			}
 			if (this.help && $args.argv.help) {
 				log('Selected help command');
 				cmd = this.commands.help;

--- a/src/context.js
+++ b/src/context.js
@@ -570,10 +570,12 @@ export default class Context extends HookEmitter {
 						}
 					}
 
-					// check for missing arguments
-					for (const len = this.args.length; i < len; i++) {
-						if (this.args[i].required) {
-							throw E.MISSING_REQUIRED_ARGUMENT(`Missing required argument "${this.args[i].name}"`, { name: 'args', scope: 'Context.parse', value: this.args[i] });
+					// check for missing arguments if help is not specifiec
+					if (!$args.argv.help) {
+						for (const len = this.args.length; i < len; i++) {
+							if (this.args[i].required) {
+								throw E.MISSING_REQUIRED_ARGUMENT(`Missing required argument "${this.args[i].name}"`, { name: 'args', scope: 'Context.parse', value: this.args[i] });
+							}
 						}
 					}
 

--- a/src/context.js
+++ b/src/context.js
@@ -460,7 +460,12 @@ export default class Context extends HookEmitter {
 				log(`Found command: ${highlight(cmd.name)}`);
 				args[i] = new ParsedArgument('command', { command: cmd });
 				$args.contexts.unshift(cmd);
+				$args.hasCommand = true;
 				return $args;
+			} else if (!cmd && Object.keys(this.commands).length) {
+				log(`Did not find command ${highlight(arg)}`);
+				$args.enteredUnknownCommand = true;
+				$args.unknownCommand = arg;
 			}
 
 			return $args;

--- a/src/context.js
+++ b/src/context.js
@@ -659,8 +659,12 @@ export default class Context extends HookEmitter {
 	 * @access private
 	 */
 	async renderHelp({ err, out, recursing } = {}) {
-		if (!out) {
-			out = this.outputStream || process.stdout;
+		if (!out && this.outputStream) {
+			out = this.outputStream;
+		} else if (!out && err) {
+			out = process.stderr;
+		} else if (!out && !err) {
+			out = process.stdout;
 		}
 
 		let ctx = this;

--- a/test/test-argument.js
+++ b/test/test-argument.js
@@ -108,7 +108,7 @@ describe('Argument', () => {
 				out
 			});
 
-			await cli.exec();
+			await cli.exec([ '--help' ]);
 
 			expect(out.toString()).to.equal([
 				'Usage: program [options] [<foo>]',
@@ -139,7 +139,7 @@ describe('Argument', () => {
 				out
 			});
 
-			await cli.exec();
+			await cli.exec([ '--help' ]);
 
 			expect(out.toString()).to.equal([
 				'Usage: program [options] <foo>',


### PR DESCRIPTION
These are fixes to align with other CLI frameworks, seen while migrating api-builder

842b5aae9bb28b4b839994e53868e0baf36e7e9c - Fixes the output stream so that if we have an error when rendering help, we render to stderr

b1f2364ea83bedde68497c2327df2afa67b3f3ea - Don't exit with the exitHelpCode when an error occurs, exit with 1

8dc5a4cf533d1f0449c28d9c130e27332351e579 - When running an invalid command `appcd foobar`, error if foobar does not exist. I believe this is not perfect due to the whole extensions business 
c1f8db468412d15ef61633090044efdb379c234e - Only error for missing args when not showing help 